### PR TITLE
Update URL for action bindings

### DIFF
--- a/.github/workflows/build_site.main.kts
+++ b/.github/workflows/build_site.main.kts
@@ -1,7 +1,7 @@
 #!/usr/bin/env kotlin
 @file:Repository("https://repo1.maven.org/maven2/")
 @file:DependsOn("io.github.typesafegithub:github-workflows-kt:2.1.0")
-@file:Repository("https://github-workflows-kt-bindings.colman.com.br/binding/")
+@file:Repository("https://bindings.krzeminski.it/")
 @file:DependsOn("actions:checkout:v4")
 @file:DependsOn("actions:setup-java:v4")
 @file:DependsOn("actions:upload-pages-artifact:v3")


### PR DESCRIPTION
The new URL is a part of stabilizing the feature of action bindings served as Maven artifacts.

For details, see the announcement:
https://kotlinlang.slack.com/archives/C02UUATR7RC/p1718314294799469